### PR TITLE
Add the with_flipped_bit method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl XorName {
 
     /// Returns the number of bits in which `self` differs from `other`.
     pub fn count_differing_bits(&self, other: &XorName) -> u32 {
-        self.0.iter().zip(other.0.iter()).map(|acc, (a, b)| acc + (a ^ b).count_ones())
+        self.0.iter().zip(other.0.iter()).fold(0, |acc, (a, b)| acc + (a ^ b).count_ones())
     }
 
     /// Compares `lhs` and `rhs` with respect to their distance from `self`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,13 @@ impl XorName {
         XOR_NAME_BITS
     }
 
+    /// Returns a copy of `self`, with the `i`-th bit flipped.
+    pub fn with_flipped_bit(&self, index: usize) -> XorName {
+        let &XorName(mut bytes) = self;
+        bytes[index / 8] = bytes[index / 8] ^ (1 << (7 - index % 8));
+        XorName(bytes)
+    }
+
     /// Compares `lhs` and `rhs` with respect to their distance from `self`.
     pub fn cmp_distance(&self, lhs: &XorName, rhs: &XorName) -> Ordering {
         for i in 0..XOR_NAME_LEN {
@@ -388,5 +395,16 @@ mod test {
         assert_eq!(&debug_id[8..14],
                    &full_id[2 * XOR_NAME_LEN - 6..2 * XOR_NAME_LEN]);
         assert_eq!(&debug_id[6..8], "..");
+    }
+
+    #[test]
+    fn with_flipped_bit() {
+        let name: XorName = rand::random();
+        for i in 0..18 {
+            assert_eq!(i, name.bucket_index(&name.with_flipped_bit(i)));
+        }
+        for i in 0..10 {
+            assert_eq!(49 * i, name.bucket_index(&name.with_flipped_bit(49 * i)));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,11 @@ impl XorName {
         Ok(XorName(bytes))
     }
 
+    /// Returns the number of bits in which `self` differs from `other`.
+    pub fn count_differing_bits(&self, other: &XorName) -> u32 {
+        self.0.iter().zip(other.0.iter()).map(|acc, (a, b)| acc + (a ^ b).count_ones())
+    }
+
     /// Compares `lhs` and `rhs` with respect to their distance from `self`.
     pub fn cmp_distance(&self, lhs: &XorName, rhs: &XorName) -> Ordering {
         for i in 0..XOR_NAME_LEN {
@@ -421,5 +426,15 @@ mod test {
         }
         assert!(name.with_flipped_bit(XOR_NAME_BITS).is_err());
         assert!(name.with_flipped_bit(XOR_NAME_BITS + 1000).is_err());
+    }
+
+    #[test]
+    fn count_differing_bits() {
+        let name: XorName = rand::random();
+        assert_eq!(0, name.count_differing_bits(&name));
+        let one_bit = unwrap_result!(name.with_flipped_bit(5));
+        assert_eq!(1, name.count_differing_bits(&one_bit));
+        let two_bits = unwrap_result!(one_bit.with_flipped_bit(100));
+        assert_eq!(2, name.count_differing_bits(&two_bits));
     }
 }


### PR DESCRIPTION
A method to flip a bit might be generally useful, and will be needed to implement the new_kademlia_routing_logic RFC, since the `i`-th _bucket address_ will be the address with the `i`-th bit flipped.