### PR TITLE
refactor(ci): Refactor of GHA CI files

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,13 +25,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       # Generate Cargo.lock, needed for the cache.
       - name: Generate lockfile
         run: cargo generate-lockfile
@@ -55,7 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
+        with:
+          fetch-depth: '0'
+
       # Is this a version change commit?
       - shell: bash
         name: Read commit message
@@ -70,6 +75,7 @@ jobs:
           version=$(grep "^version" < Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
           echo "Current version: $version"
           echo "::set-output name=version::$version"
+
       - uses: actions-rs/toolchain@v1
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
         name: Install Rust
@@ -77,6 +83,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
       # Set the tag.
       - name: Push version tag
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
@@ -84,6 +91,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: ${{ steps.versioning.outputs.version }}
+
       # Publish to crates.io.
       - name: Cargo package
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,13 +14,17 @@ jobs:
     name: clippy & fmt checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry and index
@@ -39,11 +43,37 @@ jobs:
       - name: Clippy checks
         run: cargo clippy --all-targets --all-features
 
+  coverage:
+    name: Code coverage check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust and required components
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
       # Run cargo tarpaulin & push result to coveralls.io
       - name: rust-tarpaulin code coverage check
         uses: actions-rs/tarpaulin@master
         with:
-          args: '-v --out Lcov'
+          args: '-v --release --out Lcov'
       - name: Push code coverage results to coveralls.io
         uses: coverallsapp/github-action@master
         with:
@@ -63,13 +93,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -81,6 +115,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-        # Run the tests.
+      # Run the tests.
       - name: Cargo test
         run: cargo test --release

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Moved code coverage to its own job so it runs in parallel.
Added a checkout depth of '0' when adding a tag to the repo to
ensure all commits are retrieved.