### PR TITLE
chore(cd): add continuous delivery and auto merge dependabot PRs

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -1,0 +1,37 @@
+# auto merge workflow.
+#
+# Auto merge PR if commit msg begins with `chore(release):`,
+# or if it has been raised by Dependabot.
+# Uses https://github.com/ridedott/merge-me-action.
+
+name: Merge Version Change and Dependabot PRs automatically
+
+on: pull_request
+
+jobs:
+  merge:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: get commit message
+      run: |
+           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+    - name: show commit message
+      run : echo $commitmsg
+
+    - name: Merge Version change PR
+      if: startsWith( env.commitmsg, 'chore(release):')
+      uses: ridedott/merge-me-action@81667e6ae186ddbe6d3c3186d27d91afa7475e2c
+      with:
+        GITHUB_LOGIN: dirvine
+        GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        MERGE_METHOD: REBASE
+
+    - name: Dependabot Merge
+      uses: ridedott/merge-me-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MERGE_METHOD: REBASE

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,24 @@
+name: Version bump and create PR for changes
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-20.04
+    # Dont run if we're on a release commit
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump Version
+        uses: maidsafe/rust-version-bump-branch-creator@v2
+        with:
+          token: ${{ secrets.BRANCH_CREATOR_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,37 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # only if we have a tag
+    name: Release
+    runs-on: ubuntu-20.04
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - name: Set tag as env
+        shell: bash
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
+      - name: lets check tag
+        shell: bash
+        run: echo ${{ env.RELEASE_VERSION }}
+
+      - name: Generate Changelog
+        shell: bash
+        run: awk '/# \[/{c++;p=1}{if(c==2){exit}}p;' CHANGELOG.md > RELEASE-CHANGELOG.txt
+      - run: cat RELEASE-CHANGELOG.txt
+      - name: Release generation
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        with:
+          body_path: RELEASE-CHANGELOG.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,53 +51,28 @@ jobs:
       - name: Run cargo build
         run: cargo build --release --workspace
 
+  # Publish if we're on a release commit
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs: build
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
     steps:
       - uses: actions/checkout@v2
       # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
         with:
           fetch-depth: '0'
-
-      # Is this a version change commit?
-      - shell: bash
-        name: Read commit message
-        id: commit_message
-        run: |
-          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
-          echo "::set-output name=commit_message::$commit_message"
-      - shell: bash
-        name: Fetch version number
-        id: versioning
-        run: |
-          version=$(grep "^version" < Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-          echo "Current version: $version"
-          echo "::set-output name=version::$version"
-
+     
+      # Install Rust
       - uses: actions-rs/toolchain@v1
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-        name: Install Rust
         with:
           profile: minimal
           toolchain: stable
           override: true
 
-      # Set the tag.
-      - name: Push version tag
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-        uses: anothrNick/github-tag-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_TAG: ${{ steps.versioning.outputs.version }}
-
       # Publish to crates.io.
-      - name: Cargo package
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-        run: cargo package
-      - name: Cargo publish
-        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish --token $CARGO_REGISTRY_TOKEN
+      - name: Cargo Login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Cargo Publish
+        run: cargo publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,3 +118,20 @@ jobs:
       # Run the tests.
       - name: Cargo test
         run: cargo test --release
+
+  # Test publish using --dry-run.
+  test-publish:
+    name: Test Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cargo publish dry run
+      - name: Cargo Publish Dry Run
+        run: cargo publish --dry-run

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,37 @@
+name: Tag release commit
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+  GITHUB_TOKEN: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+
+jobs:
+  tag:
+      runs-on: ubuntu-latest
+      # Only run on a release commit
+      if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: '0'
+            token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        # parse out non-tag text
+        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        # remove spaces, but add back in `v` to tag, which is needed for standard-version
+        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo $RELEASE_VERSION
+        - run: git tag $RELEASE_VERSION
+
+        - name: Setup git for push
+          run: |
+            git remote add github "$REPO"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+        - name: Push tags to master
+          run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,45 @@
-# XorName - Change Log
+# Changelog
 
-## [1.1.0]
-- Add in `XorName::random()` functionality
-- Use OSRng
+### [1.1.0](https://github.com/maidsafe/xor_name/compare/v1.0.0...v1.1.0) (2020-08-18)
+* Add in `XorName::random()` functionality
+* Use OSRng
 
-## [1.0.0]
-- Make the crate no_std
-- Add impl Deref for XorName, remove slice indexing
-- Minimise the API surface
-- Remove generics
+### [1.0.0](https://github.com/maidsafe/xor_name/compare/0.9.2...v1.0.0) (2020-07-02)
+* Make the crate no_std
+* Add impl Deref for XorName, remove slice indexing
+* Minimise the API surface
+* Remove generics
 
-## [0.9.2]
-- Remove test barrier from the FromStr trait impl for Prefix
+### [0.9.2]
+* Remove test barrier from the FromStr trait impl for Prefix
 
-## [0.9.1]
-- Added borrow trait for prefix
+### [0.9.1]
+* Added borrow trait for prefix
 
-## [0.9.0]
-- Extracted from the routing crate to become standalone (again)
-- License details updated to MIT or modified BSD license.
-- CI set up on GitHub Actions
+### [0.9.0]
+* Extracted from the routing crate to become standalone (again)
+* License details updated to MIT or modified BSD license.
+* CI set up on GitHub Actions
 
-## [0.1.0]
-- Replace CBOR usage with maidsafe_utilites::serialisation.
-- Updated dependencies.
+### [0.1.0]
+* Replace CBOR usage with maidsafe_utilites::serialisation.
+* Updated dependencies.
 
-## [0.0.5]
-- Migrate to maidsafe_utilities 0.2.1.
-- Make debug hex output lowercase.
+### [0.0.5]
+* Migrate to maidsafe_utilities 0.2.1.
+* Make debug hex output lowercase.
 
-## [0.0.4]
-- Reduce debug output to improve readability.
+### [0.0.4]
+* Reduce debug output to improve readability.
 
-## [0.0.3]
-- Add the `with_flipped_bit` and `count_differing_bits` methods.
-- Rename `cmp_closeness` to `cmp_distance`.
+### [0.0.3]
+* Add the `with_flipped_bit` and `count_differing_bits` methods.
+* Rename `cmp_closeness` to `cmp_distance`.
 
-## [0.0.2]
-- Rename `bucket_distance` to `bucket_index`.
-- Expand documentation.
-- Add `XorName::cmp_closeness` ordering method.
+### [0.0.2]
+* Rename `bucket_distance` to `bucket_index`.
+* Expand documentation.
+* Add `XorName::cmp_closeness` ordering method.
 
-## [0.0.1]
-- Initial implementation
+### [0.0.1]
+* Initial implementation


### PR DESCRIPTION
Implement a CD process where any PR merged to master will
automatically trigger a crate publish, a tag, a 'chore(release):'
PR which is auto merged, and a GitHub release.
This PR also adds auto merging for dependabot PRs which pass CI.
This PR also reformats the changelog to match the newly auto-
generated format.