### PR TITLE
chore: use deny(warnings) instead of forbid(warnings)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,10 +32,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
       
       # Cache.
       - name: Cargo cache registry, index and build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: PR
 
-on: [pull_request, push]
+on: [pull_request]
 
 env:
   # Run all cargo commands with --verbose.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,7 @@
 )]
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(
-    mutable_transmutes,
-    no_mangle_const_items,
-    unknown_crate_types,
-    warnings
-)]
+#![forbid(mutable_transmutes, no_mangle_const_items, unknown_crate_types)]
 #![deny(
     deprecated,
     improper_ctypes,
@@ -40,7 +35,8 @@
     unused_comparisons,
     unused_features,
     unused_parens,
-    while_true
+    while_true,
+    warnings
 )]
 #![warn(
     trivial_casts,


### PR DESCRIPTION
`deny` can be overriden with `allow`, unlike `forbid`. This allows us to `allow` some warnings on a case-by-case basis which is especially useful in macros. Without this, some macros from other crates caused compilation errors on nightly, however it's possible it would eventually affect stable as well.