### PR TITLE
chore(cicd): exclude prs with title `Automated version bump`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   clippy:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: clippy & fmt checks
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +42,7 @@ jobs:
         run: cargo clippy --all-targets --all-features
 
   check_pr_size:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Check PR size doesn't break set limit
     runs-on: ubuntu-latest
     steps:
@@ -52,6 +54,7 @@ jobs:
           max_lines_changed: 200
   
   coverage:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Code coverage check
     runs-on: ubuntu-latest
     steps:
@@ -91,6 +94,7 @@ jobs:
           parallel-finished: true
 
   cargo-udeps:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Unused dependency check
     runs-on: ubuntu-latest
     steps:
@@ -98,17 +102,17 @@ jobs:
       # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           override: true
 
-      # Install and run cargo udeps to find unused cargo dependencies
-      - name: cargo-udeps unused dependency check
-        run: |
-          cargo install cargo-udeps --locked
-          cargo +nightly udeps --all-targets
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
+          args: '--all-targets'
 
   cargo-deny:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -120,6 +124,7 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v1
           
   test:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -150,6 +155,7 @@ jobs:
 
   # Test publish using --dry-run.
   test-publish:
+    if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test Publish
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   audit:
+    if: github.repository_owner == 'maidsafe'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Also switches cargo udeps scan to run via dedicated github action