### PR TITLE
Prefix map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rand_core = "0.5.1"
   [dependencies.rand]
   version = "~0.7.3"
   default-features = false
+  features = ["std"]
 
   [dependencies.serde]
   version = "1.0.113"
@@ -26,6 +27,7 @@ rand_core = "0.5.1"
   features = [ "derive" ]
 
 [dev-dependencies]
+rmp-serde = "0.15.5"
 bincode = "1.2.1"
 
   [dev-dependencies.arrayvec]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand_core = "0.5.1"
 [dev-dependencies]
 rmp-serde = "0.15.5"
 bincode = "1.2.1"
+eyre = "0.6.5"
 
   [dev-dependencies.arrayvec]
   version = "~0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
     missing_debug_implementations,
     variant_size_differences
 )]
-#![no_std]
 
 use core::{cmp::Ordering, fmt, ops};
 pub use prefix::Prefix;
@@ -96,6 +95,7 @@ macro_rules! format {
 }
 
 mod prefix;
+pub mod prefix_map;
 
 /// Constant byte length of `XorName`.
 pub const XOR_NAME_LEN: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,17 +571,17 @@ mod tests {
 
     #[test]
     fn bit() {
-        assert_eq!(false, xor_name!(0b00101000).bit(0));
-        assert_eq!(true, xor_name!(0b00101000).bit(2));
-        assert_eq!(false, xor_name!(0b00101000).bit(3));
-        assert_eq!(true, xor_name!(2, 128, 1, 0).bit(6));
-        assert_eq!(true, xor_name!(2, 128, 1, 0).bit(8));
-        assert_eq!(true, xor_name!(2, 128, 1, 0).bit(23));
-        assert_eq!(false, xor_name!(2, 128, 1, 0).bit(5));
-        assert_eq!(false, xor_name!(2, 128, 1, 0).bit(7));
-        assert_eq!(false, xor_name!(2, 128, 1, 0).bit(9));
-        assert_eq!(false, xor_name!(2, 128, 1, 0).bit(22));
-        assert_eq!(false, xor_name!(2, 128, 1, 0).bit(24));
+        assert!(!xor_name!(0b00101000).bit(0));
+        assert!(xor_name!(0b00101000).bit(2));
+        assert!(!xor_name!(0b00101000).bit(3));
+        assert!(xor_name!(2, 128, 1, 0).bit(6));
+        assert!(xor_name!(2, 128, 1, 0).bit(8));
+        assert!(xor_name!(2, 128, 1, 0).bit(23));
+        assert!(!xor_name!(2, 128, 1, 0).bit(7));
+        assert!(!xor_name!(2, 128, 1, 0).bit(9));
+        assert!(!xor_name!(2, 128, 1, 0).bit(5));
+        assert!(!xor_name!(2, 128, 1, 0).bit(22));
+        assert!(!xor_name!(2, 128, 1, 0).bit(24));
     }
 
     #[test]

--- a/src/prefix_map.rs
+++ b/src/prefix_map.rs
@@ -54,7 +54,7 @@ where
             return false;
         }
 
-        let prefix = entry.borrow().clone();
+        let prefix = *entry.borrow();
         let _ = self.0.insert(prefix, entry);
 
         let parent_prefix = prefix.popped();
@@ -84,7 +84,6 @@ where
     }
 
     /// Returns an iterator over the entries, in order by prefixes.
-    // TODO check if really ordered
     pub fn iter(&self) -> impl Iterator<Item = &T> + Clone {
         self.0.iter().map(|(_, entry)| entry)
     }
@@ -190,8 +189,8 @@ impl<T> Iterator for IntoIter<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::Rng;
     use eyre::Result;
+    use rand::Rng;
 
     #[test]
     fn insert_existing_prefix() {
@@ -309,6 +308,20 @@ mod tests {
             map.get_matching_prefix(&prefix("101")),
             Some(&(prefix("10"), 10))
         );
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut map = PrefixMap::new();
+        let _ = map.insert((prefix("10"), 10));
+        let _ = map.insert((prefix("11"), 11));
+        let _ = map.insert((prefix("0"), 0));
+
+        let mut it = map.iter();
+        assert_eq!(it.next(), Some(&(prefix("0"), 0)));
+        assert_eq!(it.next(), Some(&(prefix("10"), 10)));
+        assert_eq!(it.next(), Some(&(prefix("11"), 11)));
+        assert_eq!(it.next(), None);
     }
 
     #[test]

--- a/src/prefix_map.rs
+++ b/src/prefix_map.rs
@@ -1,0 +1,396 @@
+// Copyright 2021 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+//! Container that acts as a map whose keys are prefixes.
+
+use serde::{Deserialize, Serialize};
+use std::{
+    borrow::Borrow,
+    cmp::Ordering,
+    collections::{btree_set, BTreeSet},
+};
+use crate::{Prefix, XorName};
+
+/// Container that acts as a map whose keys are prefixes.
+///
+/// It differs from a normal map of `Prefix` -> `T` in a couple of ways:
+/// 1. It allows to keep the prefix and the value in the same type which makes it internally more
+///    similar to a set of `(Prefix, T)` rather than map of `Prefix` -> `T` while still providing
+///    convenient map-like API
+/// 2. It automatically prunes redundant entries. That is, when the prefix of an entry is fully
+///    covered by other prefixes, that entry is removed. For example, when there is entry with
+///    prefix (00) and we insert entries with (000) and (001), the (00) prefix becomes fully
+///    covered and is automatically removed.
+/// 3. It provides some additional lookup API for convenience (`get_equal_or_ancestor`,
+///    `get_matching`, ...)
+///
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[allow(missing_debug_implementations)]
+#[serde(transparent)]
+pub struct PrefixMap<T>(BTreeSet<Entry<T>>)
+where
+    T: Borrow<Prefix>;
+
+impl<T> PrefixMap<T>
+where
+    T: Borrow<Prefix>,
+{
+    /// Create empty `PrefixMap`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts new entry into the map. Replaces previous entry at the same prefix.
+    /// Removes those ancestors of the inserted prefix that are now fully covered by their
+    /// descendants.
+    /// Does not insert anything if any descendant of the prefix of `entry` is already present in
+    /// the map.
+    /// Returns the previous entry with the same prefix, if any.
+    // TODO: change to return `bool` indicating whether anything changed. It's more useful for our
+    // purposes.
+    pub fn insert(&mut self, entry: T) -> Option<T> {
+        // Don't insert if any descendant is already present in the map.
+        if self.descendants(entry.borrow()).next().is_some() {
+            return Some(entry);
+        }
+
+        let parent_prefix = entry.borrow().popped();
+        let old = self.0.replace(Entry(entry));
+        self.prune(parent_prefix);
+        old.map(|entry| entry.0)
+    }
+
+    /// Get the entry at `prefix`, if any.
+    pub fn get(&self, prefix: &Prefix) -> Option<&T> {
+        self.0.get(prefix).map(|entry| &entry.0)
+    }
+
+    /// Get the entry at `prefix` or any of its ancestors. In case of multiple matches, returns the
+    /// one with the longest prefix.
+    pub fn get_equal_or_ancestor(&self, prefix: &Prefix) -> Option<&T> {
+        let mut prefix = *prefix;
+        loop {
+            if let Some(entry) = self.get(&prefix) {
+                return Some(entry);
+            }
+
+            if prefix.is_empty() {
+                return None;
+            }
+
+            prefix = prefix.popped();
+        }
+    }
+
+    /// Get the entry at the prefix that matches `name`. In case of multiple matches, returns the
+    /// one with the longest prefix.
+    pub fn get_matching(&self, name: &XorName) -> Option<&T> {
+        self.0
+            .iter()
+            .filter(|entry| entry.prefix().matches(name))
+            .max_by_key(|entry| entry.prefix().bit_count())
+            .map(|entry| &entry.0)
+    }
+
+    /// Returns an iterator over the entries, in order by prefixes.
+    pub fn iter(&self) -> impl Iterator<Item = &T> + Clone {
+        self.0.iter().map(|entry| &entry.0)
+    }
+
+    /// Returns an iterator over all entries whose prefixes are descendants (extensions) of
+    /// `prefix`.
+    pub fn descendants<'a>(
+        &'a self,
+        prefix: &'a Prefix,
+    ) -> impl Iterator<Item = &'a T> + Clone + 'a {
+        // TODO: there might be a way to do this in O(logn) using BTreeSet::range
+        self.0
+            .iter()
+            .filter(move |entry| entry.0.borrow().is_extension_of(prefix))
+            .map(|entry| &entry.0)
+    }
+
+    // Remove `prefix` and any of its ancestors if they are covered by their descendants.
+    // For example, if `(00)` and `(01)` are both in the map, we can remove `(0)` and `()`.
+    fn prune(&mut self, mut prefix: Prefix) {
+        // TODO: can this be optimized?
+
+        loop {
+            if prefix.is_covered_by(self.descendants(&prefix).map(|entry| entry.borrow())) {
+                let _ = self.0.remove(&prefix);
+            }
+
+            if prefix.is_empty() {
+                break;
+            } else {
+                prefix = prefix.popped();
+            }
+        }
+    }
+}
+
+// We have to impl this manually since the derive would require T: Default, which is not necessary.
+// See rust-lang/rust#26925
+impl<T> Default for PrefixMap<T>
+where
+    T: Borrow<Prefix>,
+{
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+// Need to impl this manually, because the derived one would use `PartialEq` of `Entry` which
+// compares only the prefixes.
+impl<T> PartialEq for PrefixMap<T>
+where
+    T: Borrow<Prefix> + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len()
+            && self
+                .0
+                .iter()
+                .zip(other.0.iter())
+                .all(|(lhs, rhs)| lhs.0 == rhs.0)
+    }
+}
+
+impl<T> Eq for PrefixMap<T> where T: Borrow<Prefix> + Eq {}
+
+impl<T> From<PrefixMap<T>> for BTreeSet<T>
+where
+    T: Borrow<Prefix> + Ord,
+{
+    fn from(map: PrefixMap<T>) -> Self {
+        map.0.into_iter().map(|entry| entry.0).collect()
+    }
+}
+
+impl<T> IntoIterator for PrefixMap<T>
+where
+    T: Borrow<Prefix>,
+{
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.0.into_iter())
+    }
+}
+
+/// An owning iterator over the values of a [`PrefixMap`].
+///
+/// This struct is created by [`PrefixMap::into_iter`].
+#[derive(Debug)]
+pub struct IntoIter<T>(btree_set::IntoIter<Entry<T>>);
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|entry| entry.0)
+    }
+}
+
+// Wrapper for entries of `PrefixMap` which implements Eq, Ord by delegating them to the prefix.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+struct Entry<T>(T);
+
+impl<T> Entry<T>
+where
+    T: Borrow<Prefix>,
+{
+    fn prefix(&self) -> &Prefix {
+        self.0.borrow()
+    }
+}
+
+impl<T> Borrow<Prefix> for Entry<T>
+where
+    T: Borrow<Prefix>,
+{
+    fn borrow(&self) -> &Prefix {
+        self.0.borrow()
+    }
+}
+
+impl<T> PartialEq for Entry<T>
+where
+    T: Borrow<Prefix>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.borrow().eq(other.0.borrow())
+    }
+}
+
+impl<T> Eq for Entry<T> where T: Borrow<Prefix> {}
+
+impl<T> Ord for Entry<T>
+where
+    T: Borrow<Prefix>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.borrow().cmp(other.0.borrow())
+    }
+}
+
+impl<T> PartialOrd for Entry<T>
+where
+    T: Borrow<Prefix>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::Rng;
+    use xor_name::Prefix;
+
+    #[test]
+    fn insert_existing_prefix() {
+        let mut map = PrefixMap::new();
+        assert_eq!(map.insert((prefix("0"), 1)), None);
+        assert_eq!(map.insert((prefix("0"), 2)), Some((prefix("0"), 1)));
+        assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 2)));
+    }
+
+    #[test]
+    fn insert_direct_descendants_of_existing_prefix() {
+        let mut map = PrefixMap::new();
+        assert_eq!(map.insert((prefix("0"), 0)), None);
+
+        // Insert the first sibling. Parent remain in the map.
+        assert_eq!(map.insert((prefix("00"), 1)), None);
+        assert_eq!(map.get(&prefix("00")), Some(&(prefix("00"), 1)));
+        assert_eq!(map.get(&prefix("01")), None);
+        assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 0)));
+
+        // Insert the other sibling. Parent is removed because it is now fully covered by its
+        // descendants.
+        assert_eq!(map.insert((prefix("01"), 2)), None);
+        assert_eq!(map.get(&prefix("00")), Some(&(prefix("00"), 1)));
+        assert_eq!(map.get(&prefix("01")), Some(&(prefix("01"), 2)));
+        assert_eq!(map.get(&prefix("0")), None);
+    }
+
+    #[test]
+    fn insert_indirect_descendants_of_existing_prefix() {
+        let mut map = PrefixMap::new();
+        assert_eq!(map.insert((prefix("0"), 0)), None);
+
+        assert_eq!(map.insert((prefix("000"), 1)), None);
+        assert_eq!(map.get(&prefix("000")), Some(&(prefix("000"), 1)));
+        assert_eq!(map.get(&prefix("001")), None);
+        assert_eq!(map.get(&prefix("00")), None);
+        assert_eq!(map.get(&prefix("01")), None);
+        assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 0)));
+
+        assert_eq!(map.insert((prefix("001"), 2)), None);
+        assert_eq!(map.get(&prefix("000")), Some(&(prefix("000"), 1)));
+        assert_eq!(map.get(&prefix("001")), Some(&(prefix("001"), 2)));
+        assert_eq!(map.get(&prefix("00")), None);
+        assert_eq!(map.get(&prefix("01")), None);
+        assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 0)));
+
+        assert_eq!(map.insert((prefix("01"), 3)), None);
+        assert_eq!(map.get(&prefix("000")), Some(&(prefix("000"), 1)));
+        assert_eq!(map.get(&prefix("001")), Some(&(prefix("001"), 2)));
+        assert_eq!(map.get(&prefix("00")), None);
+        assert_eq!(map.get(&prefix("01")), Some(&(prefix("01"), 3)));
+        // (0) is now fully covered and so was removed
+        assert_eq!(map.get(&prefix("0")), None);
+    }
+
+    #[test]
+    fn insert_ancestor_of_existing_prefix() {
+        let mut map = PrefixMap::new();
+        let _ = map.insert((prefix("00"), 1));
+
+        assert_eq!(map.insert((prefix("0"), 2)), Some((prefix("0"), 2)));
+        assert_eq!(map.get(&prefix("0")), None);
+        assert_eq!(map.get(&prefix("00")), Some(&(prefix("00"), 1)));
+    }
+
+    #[test]
+    fn get_equal_or_ancestor() {
+        let mut map = PrefixMap::new();
+        let _ = map.insert((prefix("0"), 0));
+        let _ = map.insert((prefix("10"), 1));
+
+        assert_eq!(
+            map.get_equal_or_ancestor(&prefix("0")),
+            Some(&(prefix("0"), 0))
+        );
+        assert_eq!(
+            map.get_equal_or_ancestor(&prefix("00")),
+            Some(&(prefix("0"), 0))
+        );
+        assert_eq!(
+            map.get_equal_or_ancestor(&prefix("01")),
+            Some(&(prefix("0"), 0))
+        );
+
+        assert_eq!(map.get_equal_or_ancestor(&prefix("1")), None);
+        assert_eq!(
+            map.get_equal_or_ancestor(&prefix("10")),
+            Some(&(prefix("10"), 1))
+        );
+        assert_eq!(
+            map.get_equal_or_ancestor(&prefix("100")),
+            Some(&(prefix("10"), 1))
+        );
+    }
+
+    #[test]
+    fn get_matching() {
+        let mut rng = rand::thread_rng();
+
+        let mut map = PrefixMap::new();
+        let _ = map.insert((prefix("0"), 0));
+        let _ = map.insert((prefix("1"), 1));
+        let _ = map.insert((prefix("10"), 10));
+
+        assert_eq!(
+            map.get_matching(&prefix("0").substituted_in(rng.gen())),
+            Some(&(prefix("0"), 0))
+        );
+
+        assert_eq!(
+            map.get_matching(&prefix("11").substituted_in(rng.gen())),
+            Some(&(prefix("1"), 1))
+        );
+
+        assert_eq!(
+            map.get_matching(&prefix("10").substituted_in(rng.gen())),
+            Some(&(prefix("10"), 10))
+        );
+    }
+
+    #[test]
+    fn serialize_transparent() {
+        let mut map = PrefixMap::new();
+        let _ = map.insert((prefix("0"), 0));
+        let _ = map.insert((prefix("1"), 1));
+        let _ = map.insert((prefix("10"), 10));
+
+        let set: BTreeSet<_> = map.clone().into_iter().collect();
+        let serialized_set = rmp_serde::to_vec(&set).unwrap();
+
+        assert_eq!(rmp_serde::to_vec(&map).unwrap(), serialized_set);
+        let _ = rmp_serde::from_read::<_, PrefixMap<(Prefix, i32)>>(&*serialized_set).unwrap();
+    }
+
+    fn prefix(s: &str) -> Prefix {
+        s.parse().unwrap()
+    }
+}

--- a/src/prefix_map.rs
+++ b/src/prefix_map.rs
@@ -195,25 +195,25 @@ mod tests {
     #[test]
     fn insert_existing_prefix() {
         let mut map = PrefixMap::new();
-        assert_eq!(map.insert((prefix("0"), 1)), true);
-        assert_eq!(map.insert((prefix("0"), 2)), true);
+        assert!(map.insert((prefix("0"), 1)));
+        assert!(map.insert((prefix("0"), 2)));
         assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 2)));
     }
 
     #[test]
     fn insert_direct_descendants_of_existing_prefix() {
         let mut map = PrefixMap::new();
-        assert_eq!(map.insert((prefix("0"), 0)), true);
+        assert!(map.insert((prefix("0"), 0)));
 
         // Insert the first sibling. Parent remain in the map.
-        assert_eq!(map.insert((prefix("00"), 1)), true);
+        assert!(map.insert((prefix("00"), 1)));
         assert_eq!(map.get(&prefix("00")), Some(&(prefix("00"), 1)));
         assert_eq!(map.get(&prefix("01")), None);
         assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 0)));
 
         // Insert the other sibling. Parent is removed because it is now fully covered by its
         // descendants.
-        assert_eq!(map.insert((prefix("01"), 2)), true);
+        assert!(map.insert((prefix("01"), 2)));
         assert_eq!(map.get(&prefix("00")), Some(&(prefix("00"), 1)));
         assert_eq!(map.get(&prefix("01")), Some(&(prefix("01"), 2)));
         assert_eq!(map.get(&prefix("0")), None);
@@ -222,23 +222,23 @@ mod tests {
     #[test]
     fn insert_indirect_descendants_of_existing_prefix() {
         let mut map = PrefixMap::new();
-        assert_eq!(map.insert((prefix("0"), 0)), true);
+        assert!(map.insert((prefix("0"), 0)));
 
-        assert_eq!(map.insert((prefix("000"), 1)), true);
+        assert!(map.insert((prefix("000"), 1)));
         assert_eq!(map.get(&prefix("000")), Some(&(prefix("000"), 1)));
         assert_eq!(map.get(&prefix("001")), None);
         assert_eq!(map.get(&prefix("00")), None);
         assert_eq!(map.get(&prefix("01")), None);
         assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 0)));
 
-        assert_eq!(map.insert((prefix("001"), 2)), true);
+        assert!(map.insert((prefix("001"), 2)));
         assert_eq!(map.get(&prefix("000")), Some(&(prefix("000"), 1)));
         assert_eq!(map.get(&prefix("001")), Some(&(prefix("001"), 2)));
         assert_eq!(map.get(&prefix("00")), None);
         assert_eq!(map.get(&prefix("01")), None);
         assert_eq!(map.get(&prefix("0")), Some(&(prefix("0"), 0)));
 
-        assert_eq!(map.insert((prefix("01"), 3)), true);
+        assert!(map.insert((prefix("01"), 3)));
         assert_eq!(map.get(&prefix("000")), Some(&(prefix("000"), 1)));
         assert_eq!(map.get(&prefix("001")), Some(&(prefix("001"), 2)));
         assert_eq!(map.get(&prefix("00")), None);
@@ -252,7 +252,7 @@ mod tests {
         let mut map = PrefixMap::new();
         let _ = map.insert((prefix("00"), 1));
 
-        assert_eq!(map.insert((prefix("0"), 2)), false);
+        assert!(!map.insert((prefix("0"), 2)));
         assert_eq!(map.get(&prefix("0")), None);
         assert_eq!(map.get(&prefix("00")), Some(&(prefix("00"), 1)));
     }


### PR DESCRIPTION
- add prefix map to xor_name crate
- remove unused `get_equal_or_ancestor` function
- have the insert method return `bool` as TODO comment suggested
- make `prune` pub
- add a `get_matching_prefix` method
- replace `BTreeSet` with `BTreeMap` which simplifies the code a LOT