### PR TITLE
refactor(prefix-map): remove the requirement of Borrow<Prefix> trait for T from PrefixMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 
 use core::{cmp::Ordering, fmt, ops};
 pub use prefix::Prefix;
+pub use prefix_map::PrefixMap;
 use rand::{
     distributions::{Distribution, Standard},
     rngs::OsRng,
@@ -95,7 +96,7 @@ macro_rules! format {
 }
 
 mod prefix;
-pub mod prefix_map;
+mod prefix_map;
 
 /// Constant byte length of `XorName`.
 pub const XOR_NAME_LEN: usize = 32;

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -9,7 +9,6 @@
 
 use crate::{XorName, XOR_NAME_LEN};
 use core::{
-    borrow::Borrow,
     cmp::{self, Ordering},
     fmt::{Binary, Debug, Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
@@ -278,12 +277,6 @@ impl Binary for Prefix {
 impl Debug for Prefix {
     fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
         write!(formatter, "Prefix({:b})", self)
-    }
-}
-
-impl<T> Borrow<Prefix> for (Prefix, T) {
-    fn borrow(&self) -> &Prefix {
-        &self.0
     }
 }
 


### PR DESCRIPTION
- Expose PrefixMap as public from lib
- Adapt PrefixMap APIs to the removal of requirement of Borrow<Prefix> Trait for T