### PR TITLE
Use Dashmap instead of BTreeMap for better concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ repository = "https://github.com/maidsafe/xor_name"
 [dependencies]
 rand_core = "0.5.1"
 
+  [dependencies.dashmap]
+  version = "4.0.2"
+  features = [ "serde" ]
+
   [dependencies.tiny-keccak]
   version = "~2.0"
   features = [ "sha3" ]

--- a/src/prefix_map.rs
+++ b/src/prefix_map.rs
@@ -74,7 +74,7 @@ where
         self.get_matching(&prefix.name())
     }
 
-    /// Returns an iterator over the entries
+    /// Returns an owning iterator over the entries
     pub fn iter(&self) -> impl Iterator<Item = (Prefix, T)> + '_ {
         self.0
             .iter()


### PR DESCRIPTION
- replaces `BTreeMap` with `DashMap` to improve concurrency
- changes the return of `get*` and `iter` methods to owned copies `Option<(Prefix, T)>` instead of refs due to `DashMap`'s concurrency implementation