### PR TITLE
Impl different Prefix format (binary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ XorName is an array that is useful for calculations in DHT
 
 ## Serialization
 
-`XorName` and `Prefix` can be serialized into a human-readable hex string, instead of as a `u8` array. To enable this, activate the `serialize-hex` feature. This also allows for these structures to be serialised when used as a key in a map like `HashMap`, because most formats only allow keys to be strings, instead of more complex types.
+`XorName` and `Prefix` are serialized into a human-readable hex string, instead of as a `u8` array. This is enabled by default, with the `serialize-hex` feature. This also allows for these structures to be serialised when used as a key in a map like `HashMap`, because most formats only allow keys to be strings, instead of more complex types.
 
 A struct like this:
 ```rust
@@ -21,8 +21,8 @@ struct MyStruct {
 Will yield this JSON
 ```json
 {
-  "prefix": "8a817b6d791f4b00000000000000000000000000000000000000000000000000/56",
-  "xor_name": "8a817b6d791f4bae4117ac7ae15a88cd2c62fba0b040972ce885f1a47625dea1"
+  "prefix": "10001101110001111100101000111001101101111101111010011001",
+  "xor_name": "8dc7ca39b7de990eb943fd64854776dd85aa82c33a4269693c57b36e0749ed8f"
 }
 ```
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -283,6 +283,14 @@ impl Debug for Prefix {
     }
 }
 
+/// Format `Prefix` as bit string, e.g. `"010"` with a [`Prefix::bit_count`] of `3`.
+impl Display for Prefix {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Use `Binary` impl from `XorName` with restricted width
+        write!(f, "{:width$b}", self.name, width = self.bit_count as usize)
+    }
+}
+
 #[derive(Debug)]
 pub enum FromStrError {
     InvalidChar(char),
@@ -296,11 +304,11 @@ impl Display for FromStrError {
                 write!(f, "expected `0` or `1`, but encountered `{}`", c)
             }
             FromStrError::TooLong(l) => {
-        write!(
+                write!(
                     f,
                     "max length exceeded {} with length of {l}",
                     XOR_NAME_LEN * 8
-        )
+                )
             }
         }
     }
@@ -446,6 +454,16 @@ mod tests {
 
         // Bit string with 257 width
         assert!(Prefix::from_str(&"1".repeat(XOR_NAME_LEN * 8 + 1)).is_err());
+    }
+
+    #[test]
+    fn format_parse_roundtrip() {
+        let format_parse_eq = |p| p == parse(&std::format!("{}", p));
+
+        assert!(format_parse_eq(Prefix::new(0, XorName([0xBB; 32]))));
+        assert!(format_parse_eq(Prefix::new(256, XorName([0x33; 32]))));
+        assert!(format_parse_eq(Prefix::new(5, XorName([0xAA; 32]))));
+        assert!(format_parse_eq(Prefix::new(76, XorName([0xAA; 32]))));
     }
 
     fn parse(input: &str) -> Prefix {

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -306,7 +306,7 @@ impl FromStr for Prefix {
         for (i, bit) in bits.chars().enumerate() {
             if bit == '1' {
                 let byte = i / 8;
-                name[byte] |= 1 << (7 - i);
+                name[byte] |= 1 << (7 - (i % 8));
             } else if bit != '0' {
                 return Err(FromStrError { invalid_char: bit });
             }


### PR DESCRIPTION
Change Prefix to format into strings like "001010100" instead of a hex string with suffix like "/11".

Also fixes `FromStr` impl to allow for a larger string to be parsed into `Prefix` and to error out on a string that is too long.

- fix: allow prefix strings of more than one byte
- fix!: error instead of panic on too long string
- feat: impl Display for Prefix
- feat: different Prefix serialization format
- docs: edit README.md to reflect default feature
