### PR TITLE
feat(api): make `from_content_parts` accept Vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,8 +662,8 @@ mod tests {
 
     #[test]
     fn xor_name_from_content() {
-        let alpha_1 = XorName::from_content_parts(&[b"abcdefg", b"hijk"]);
-        let alpha_2 = XorName::from_content_parts(&[b"abcdefg", b"hijk"]);
+        let alpha_1 = XorName::from_content_parts(vec![b"abcdefg".to_vec(), b"hijk".to_vec()]);
+        let alpha_2 = XorName::from_content_parts(vec![b"abcdefg".to_vec(), b"hijk".to_vec()]);
         let alpha_3 = XorName::from_content(b"abcdefg");
 
         assert_eq!(alpha_1, alpha_2);
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn xor_name_from_content_is_agnostic_to_where_content_parts_splits() {
-        let alpha_1 = XorName::from_content_parts(&[b"abcdefg", b"hijk"]);
+        let alpha_1 = XorName::from_content_parts(vec![b"abcdefg".to_vec(), b"hijk".to_vec()]);
         let alpha_2 = XorName::from_content(b"abcdefghijk");
         assert_eq!(alpha_1, alpha_2);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,14 +114,14 @@ pub struct XorName(pub [u8; XOR_NAME_LEN]);
 impl XorName {
     /// Generate a XorName for the given content.
     pub fn from_content(content: &[u8]) -> Self {
-        Self::from_content_parts(&[content])
+        Self::from_content_parts(vec![content.to_vec()])
     }
 
     /// Generate a XorName for the given content (for content-addressable-storage)
-    pub fn from_content_parts(content_parts: &[&[u8]]) -> Self {
+    pub fn from_content_parts(content_parts: Vec<Vec<u8>>) -> Self {
         let mut sha3 = Sha3::v256();
         for part in content_parts {
-            sha3.update(part);
+            sha3.update(&part);
         }
         let mut hash = [0u8; XOR_NAME_LEN];
         sha3.finalize(&mut hash);


### PR DESCRIPTION
it makes it easier to use, for example here:
https://github.com/maidsafe/safe_network_archive/blob/37f5b2391d5453f657cf840dd70efae4167502b3/sn_interface/src/network_knowledge/node_state/relocation.rs#L54